### PR TITLE
Exposed ctags cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ manually.
 
 ## Dependencies
 For this plugin to work, you need working [ctags][2] and [readtags][3] programs.
-Note that [readtags][3] isn't shipped with [excuberant-ctags][2] by default (you
+Note that [readtags][3] isn't shipped with [exuberant-ctags][2] by default (you
 can use [universal-ctags][5]).
 
 
@@ -36,7 +36,12 @@ Tagbar.kak supports configuration via these options:
 - `tagbar_side` - defines what side of the tmux pane should be used to open tagbar;
 - `tagbar_size` - defines width or height in cells or percents;
 - `tagbar_split` - defines how to split tmux pane, horizontally or vertically;
-- `tagbarclient` - defines name of the client that tagbar will create and use to display itself.
+- `tagbarclient` - defines name of the client that tagbar will create and use to
+  display itself.
+- `tagbar_ctags_cmd` - defines what command will be used to generate tag
+  file. This option was added to allow setting custom ctags-compatible
+  executable for languages that are not supported by ctags package, but have a
+  compatible parser.
 
 ### Automatic startup
 To start tagbar.kak automatically on certain filetypes, you can use this hook:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ Tagbar.kak supports configuration via these options:
 - `tagbar_ctags_cmd` - defines what command will be used to generate tag
   file. This option was added to allow setting custom ctags-compatible
   executable for languages that are not supported by ctags package, but have a
-  compatible parser.
+  compatible parser. If you want to set up **tagbar.kak** for unsupported
+  language, you also need to populate `tagbar_kinds` option with pairs of kinds
+  for the language. For example, for C, kinds are defined as follows `'f'
+  'Function Definitions'`, `'g' 'Enumeration Names'`, `'h' 'Included Header
+  files'`, and so on.
 
 ### Automatic startup
 To start tagbar.kak automatically on certain filetypes, you can use this hook:

--- a/rc/tagbar.kak
+++ b/rc/tagbar.kak
@@ -520,7 +520,7 @@ try %{
     hook global WinSetOption filetype=nim %sh{
         if [ -n "$(command -v ntags)" ]; then
             printf "%s\n" "set-option window tagbar_ctags_cmd 'ntags'
-                           set-option window tagbar_kinds 'f' 'Functions' 't' 'Types' 'v' 'Variables'"
+                           set-option window tagbar_kinds 'f' 'Procedures' 't' 'Types' 'v' 'Variables'"
         fi
     }
 }


### PR DESCRIPTION
**Breaking change**: no
<!-- Please provide meaningful description about your contribution -->
**Description**:
Provides an option to configure `ctags` implementations. Executable must provide `ctags` compatible output and at least accept `-f` flag.

Fix #4 
<!-- note that code will be reviewed and changes much likely will be requested -->
