### PR TITLE
Reset search register on jump

### DIFF
--- a/rc/tagbar.kak
+++ b/rc/tagbar.kak
@@ -179,7 +179,7 @@ define-command -hidden tagbar-update -params ..1 %{ evaluate-commands %sh{
     printf "%s\n" "evaluate-commands -client %opt{tagbarclient} %{
                        edit! -debug -fifo ${fifo} *tagbar*
                        set-option buffer filetype tagbar
-                       map buffer normal '<ret>' '<a-h>;/: <c-v><c-i><ret><a-h>2<s-l><a-l><a-;>:<space>tagbar-jump ${kak_bufname}<ret>'
+                       map buffer normal '<ret>' '<a-h>;/: <c-v><c-i><ret><a-h>2<s-l><a-l><a-;>: reg /<ret>:<space>tagbar-jump ${kak_bufname}<ret>'
                        try %{
                            set-option window tabstop 1
                            remove-highlighter window/wrap


### PR DESCRIPTION
**Breaking change**: no

Resets search register before performing jump, to remove highlighting artifacts on some configuration.
![image](https://user-images.githubusercontent.com/10168645/54748652-ea74fd00-4bda-11e9-9b1d-413a8b351e81.png)

is there a reason to use `<space>` over the literal space character?