### PR TITLE
Fix the latex filetype hook

### DIFF
--- a/rc/tagbar.kak
+++ b/rc/tagbar.kak
@@ -497,7 +497,7 @@ try %{
     hook global WinSetOption filetype=tcloo %{
         set-option window tagbar_kinds 'c' 'Classes' 'm' 'Methods'
     }
-    hook global WinSetOption filetype=tex %{
+    hook global WinSetOption filetype=latex %{
         set-option window tagbar_kinds 'p' 'Parts' 'c' 'Chapters' 's' 'Sections' 'u' 'Subsections' 'b' 'Subsubsections' 'P' 'Paragraphs' 'G' 'Subparagraphs' 'l' 'Labels' 'i' 'Includes'
     }
     hook global WinSetOption filetype=ttcn %{


### PR DESCRIPTION
**Breaking change**: no
<!-- Please provide meaningful description about your contribution -->
**Description**:
The filetype for tex files in kakoune is latex, not tex. I just changed that.

<!-- note that code will be reviewed and changes much likely will be requested -->
