### PR TITLE
Add support for kitty

### DIFF
--- a/rc/tagbar.kak
+++ b/rc/tagbar.kak
@@ -138,6 +138,18 @@ define-command -hidden tagbar-display %{ nop %sh{
         [ "${kak_opt_tagbar_side}" = "left" ] && side="-b" || side=
         [ -n "${kak_opt_tagbar_size%%*%}" ] && measure="-l" || measure="-p"
         tmux split-window ${split} ${side} ${measure} ${kak_opt_tagbar_size%%%*} kak -c ${kak_session} -e "${tagbar_cmd}"
+
+    elif [ "$TERM" = "xterm-kitty" ]; then
+        match=""
+        if [ -n "$kak_client_env_KITTY_WINDOW_ID" ]; then
+            match="--match=id:$kak_client_env_KITTY_WINDOW_ID"
+        fi
+
+        listen=""
+        if [ -n "$kak_client_env_KITTY_LISTEN_ON" ]; then
+            listen="--to=$kak_client_env_KITTY_LISTEN_ON"
+        fi
+        kitty @ $listen launch --no-response --type="$kak_opt_kitty_window_type" --cwd="$PWD" $match kak -c ${kak_session} -e "${tagbar_cmd}"
     elif [ -n "${kak_opt_termcmd}" ]; then
         ( ${kak_opt_termcmd} "sh -c 'kak -c ${kak_session} -e \"${tagbar_cmd}\"'" ) > /dev/null 2>&1 < /dev/null &
     fi


### PR DESCRIPTION
**Breaking change**: no
<!-- Please provide meaningful description about your contribution -->
**Description**:
I've been playing around with tagbar for a bit, and realized that it's not able to open a new window when running under kitty in macOS. What's added here is almost the same as in https://github.com/mawww/kakoune/blob/master/rc/windowing/kitty.kak#L18-L28, although I'm not sure at all that this is the right way to solve the problem.